### PR TITLE
fix(test): deflake ScreenRecorder GIF export assertion

### DIFF
--- a/src/__tests__/components/ScreenRecorder.test.tsx
+++ b/src/__tests__/components/ScreenRecorder.test.tsx
@@ -265,10 +265,8 @@ describe("ScreenRecorder", () => {
     });
     await user.click(exportBtn);
 
-    const { toast } = await import("sonner");
-    await waitFor(() => expect(toast.success).toHaveBeenCalled());
     // GIF was constructed with the self-hosted worker path (no CDN).
-    expect(gifInstances.length).toBeGreaterThan(0);
+    await waitFor(() => expect(gifInstances.length).toBeGreaterThan(0));
     expect(lastGifOptions.value?.workerScript).toBe("/gif.worker.js");
   });
 });


### PR DESCRIPTION
## Summary
- `ScreenRecorder.test.tsx` was racing in CI: `toast.success` is called twice (recording stop and GIF finished), so `waitFor(toast.success was called)` resolved on the stop callback before `new GIF()` had run.
- Replaced with a direct `waitFor(gifInstances.length > 0)` — that's the actual condition the assertion cares about.
- Passes locally; unblocks PR #26 (zh-CN locale).

## Test plan
- [x] `bun run test src/__tests__/components/ScreenRecorder.test.tsx` passes locally
- [ ] CI green on this PR