### PR TITLE
feat: popularity-ranked default tool grid

### DIFF
--- a/src/__tests__/lib/tool-popularity.test.ts
+++ b/src/__tests__/lib/tool-popularity.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { TOOL_POPULARITY, popularityRank } from "@/lib/tool-popularity";
+import { tools } from "@/lib/tools-config";
+
+describe("tool popularity ranking", () => {
+  it("every ranked slug exists in the catalog", () => {
+    const slugs = new Set(
+      tools.flatMap((c) => c.items.map((t) => t.href.split("/").pop())),
+    );
+    for (const slug of TOOL_POPULARITY) {
+      expect(slugs.has(slug), `unknown slug: ${slug}`).toBe(true);
+    }
+  });
+
+  it("has no duplicate entries", () => {
+    expect(new Set(TOOL_POPULARITY).size).toBe(TOOL_POPULARITY.length);
+  });
+
+  it("analytics tier leads: depth-map first, pdf second", () => {
+    expect(popularityRank("depth-map")).toBe(0);
+    expect(popularityRank("pdf")).toBe(1);
+    expect(popularityRank("depth-map")).toBeLessThan(popularityRank("qr-generator"));
+  });
+
+  it("unranked tools sort after all ranked ones", () => {
+    expect(popularityRank("chmod")).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/src/components/landing/landing.tsx
+++ b/src/components/landing/landing.tsx
@@ -32,6 +32,7 @@ import { useCategoryFilterStore } from "@/store/category-filter-store";
 import HomeFAQ from "@/components/HomeFAQ";
 import { ToolTile } from "@/components/shared/ToolTile";
 import { CHIP } from "@/lib/category-chips";
+import { popularityRank } from "@/lib/tool-popularity";
 import s from "./landing.module.css";
 
 /* Locale-independent flat index — names/labels resolve via i18n at render. */
@@ -506,7 +507,11 @@ export default function Landing() {
         name: tc(`tools.${tool.slug}.name` as never) as string,
         catLabel: tc(`categoriesShort.${tool.categoryId}` as never) as string,
         description: tc(`tools.${tool.slug}.description` as never) as string,
-      })).sort((a, b) => a.name.localeCompare(b.name)),
+      })).sort(
+        (a, b) =>
+          popularityRank(a.slug) - popularityRank(b.slug) ||
+          a.name.localeCompare(b.name),
+      ),
     [tc],
   );
 

--- a/src/lib/tool-popularity.ts
+++ b/src/lib/tool-popularity.ts
@@ -1,0 +1,74 @@
+/**
+ * Default ordering for the landing "Popular" grid (Everything / no filter).
+ *
+ * Tier 1 (ranks 1-13) — the site's own most-visited tools, in order, from
+ * Vercel Analytics top-pages (owner-provided, 2026-07-13 screenshot).
+ *
+ * Tier 2 — remaining tools ranked by external search demand: directional
+ * Google query volume for each tool's head terms ("merge pdf", "qr code
+ * generator", "password generator", "word counter", ...). Volumes are
+ * directional tiers, not exact counts; revisit when Search Console data
+ * accumulates post-launch.
+ *
+ * Unlisted slugs fall back to locale-aware alphabetical after the ranked set
+ * (see landing.tsx catalog sort).
+ */
+export const TOOL_POPULARITY: string[] = [
+  // — Tier 1: site analytics (exact order from top-pages) —
+  "depth-map",
+  "pdf",
+  "bg-removal",
+  "audio-transcriber",
+  "photo-censor",
+  "phone-mockups",
+  "image-resizer",
+  "image-captioner",
+  "screenshot-beautifier",
+  "image-compression",
+  "compress-video",
+  "meme-generator",
+  "video",
+  // — Tier 2: search-demand ranking (head-term volume, descending) —
+  "qr-generator",        // "qr code generator" — one of the largest utility queries
+  "password-generator",
+  "image-converter",     // heic→jpg / webp→png conversions
+  "unit-converter",
+  "text-counter",        // "word counter"
+  "json-formatter",
+  "currency-converter",
+  "translator",
+  "speech-to-text",
+  "text-to-speech",
+  "invoice",
+  "age-calculator",
+  "bmi-calculator",
+  "loan-calculator",
+  "percentage-calculator",
+  "gif-maker",
+  "screen-recorder",
+  "base64",
+  "markdown-editor",
+  "audio",               // audio cutter/editor queries
+  "favicon-generator",
+  "svg-png",
+  "color-converter",
+  "color-palette",
+  "css-gradient",
+  "timer",
+  "pomodoro",
+  "stopwatch",
+  "regex-tester",
+  "hash-generator",
+  "barcode-generator",
+  "emoji-picker",
+  "fake-data",
+  "text-case",
+  "text-diff",
+];
+
+const RANK = new Map(TOOL_POPULARITY.map((slug, i) => [slug, i]));
+
+/** Sort key: ranked tools first (analytics, then search demand), rest ∞. */
+export function popularityRank(slug: string): number {
+  return RANK.get(slug) ?? Number.POSITIVE_INFINITY;
+}


### PR DESCRIPTION
Default (Everything) grid order: the site's top-visited tools first (owner analytics, exact order from top-pages), then the rest by directional search-engine demand for each tool's head terms, then alphabetical fallback. Data lives in `src/lib/tool-popularity.ts` with tests (slug validity, no dupes, tier order). Live-verified: grid renders depth-map → pdf → bg-removal → … → qr-generator.