### PR TITLE
feat: surface PDF operations as their own tool cards

### DIFF
--- a/src/__tests__/lib/tools-config-landing.test.ts
+++ b/src/__tests__/lib/tools-config-landing.test.ts
@@ -3,13 +3,14 @@ import {
   getAllTools,
   getCatalogTools,
   getRelatedTools,
+  isHiddenVariant,
   roundedToolCount,
   type Tool,
 } from "@/lib/tools-config";
 
-/* Synthetic pool for the landing-variant related-tile rules. No `landingFor`
-   entries exist in the real config yet (Task 3 adds them), so the family-aware
-   branch is exercised against an injected fixture. */
+/* Synthetic pool for the landing-variant related-tile rules — exercises the
+   family-aware branch against an injected fixture, independent of the real
+   config's variants. */
 const FakeIcon = (() => null) as unknown as Tool["icon"];
 const mk = (
   slug: string,
@@ -39,10 +40,10 @@ const POOL: (Tool & { category: string })[] = [
 ];
 
 describe("getCatalogTools", () => {
-  it("is exported and returns getAllTools filtered to entries without landingFor", () => {
+  it("returns getAllTools minus hidden variants (landingFor without inGrid)", () => {
     const catalog = getCatalogTools();
-    expect(catalog.every((t) => !t.landingFor)).toBe(true);
-    const expected = getAllTools().filter((t) => !t.landingFor);
+    expect(catalog.every((t) => !isHiddenVariant(t))).toBe(true);
+    const expected = getAllTools().filter((t) => !isHiddenVariant(t));
     expect(catalog).toEqual(expected);
   });
 
@@ -50,11 +51,33 @@ describe("getCatalogTools", () => {
     expect(getCatalogTools().length).toBeLessThanOrEqual(getAllTools().length);
   });
 
+  it("includes surfaced (inGrid) PDF variants but excludes hidden SEO variants", () => {
+    const slugs = getCatalogTools().map((t) => t.href.split("/").pop());
+    // merge-pdf is a landingFor:"pdf" variant flagged inGrid — a real card.
+    expect(slugs).toContain("merge-pdf");
+    expect(slugs).toContain("sign-pdf");
+    // compress-image-to-20kb is a plain long-tail variant — stays hidden.
+    expect(slugs).not.toContain("compress-image-to-20kb");
+  });
+
   it("excludes landing variants from the pool (synthetic)", () => {
     const slugOf = (t: { href: string }) => t.href.split("/").pop();
-    const catalogSlugs = POOL.filter((t) => !t.landingFor).map(slugOf);
+    const catalogSlugs = POOL.filter((t) => !isHiddenVariant(t)).map(slugOf);
     expect(catalogSlugs).not.toContain("compress-image-to-20kb");
     expect(catalogSlugs).toContain("compress-image");
+  });
+});
+
+describe("isHiddenVariant", () => {
+  const base = POOL[0];
+  it("hides a landingFor variant with no inGrid flag", () => {
+    expect(isHiddenVariant({ ...base, landingFor: "x" })).toBe(true);
+  });
+  it("surfaces a landingFor variant flagged inGrid", () => {
+    expect(isHiddenVariant({ ...base, landingFor: "x", inGrid: true })).toBe(false);
+  });
+  it("treats a plain tool (no landingFor) as visible", () => {
+    expect(isHiddenVariant(base)).toBe(false);
   });
 });
 

--- a/src/components/landing/landing.tsx
+++ b/src/components/landing/landing.tsx
@@ -21,7 +21,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { tools, getAllTools } from "@/lib/tools-config";
+import { tools, getAllTools, isHiddenVariant } from "@/lib/tools-config";
 import { FEATURED_APPS, type FeaturedApp } from "@/lib/featured-apps";
 import { routeFile, extOf, type RouteMatch } from "@/lib/file-router";
 import { playCue } from "@/lib/ui-sound";
@@ -36,12 +36,13 @@ import { popularityRank } from "@/lib/tool-popularity";
 import s from "./landing.module.css";
 
 /* Locale-independent flat index — names/labels resolve via i18n at render.
-   SEO landing variants (entries with `landingFor`) are excluded everywhere on
-   the landing: they must stay off the homepage grid, category counts and the
-   marketing tool count (they remain crawlable via their own routes/sitemap). */
+   Hidden SEO landing variants are excluded everywhere on the landing: they stay
+   off the homepage grid, category counts and the marketing tool count (they
+   remain crawlable via their own routes/sitemap). `inGrid` variants (the PDF
+   operations) are NOT hidden — they surface as their own cards. */
 const TOOL_INDEX = tools.flatMap((c) =>
   c.items
-    .filter((t) => !t.landingFor)
+    .filter((t) => !isHiddenVariant(t))
     .map((t) => ({
       slug: t.href.split("/").pop() as string,
       href: t.href,
@@ -62,7 +63,7 @@ const CATEGORIES = tools
   .sort((a, b) => a.order - b.order)
   .map((c) => ({
     id: c.id,
-    count: c.items.filter((t) => !t.landingFor).length,
+    count: c.items.filter((t) => !isHiddenVariant(t)).length,
   }));
 
 /* Full catalog grouped by category for the crawlable "All tools" surface.
@@ -74,7 +75,7 @@ const GROUPED = tools
   .map((c) => ({
     id: c.id,
     items: c.items
-      .filter((t) => !t.landingFor)
+      .filter((t) => !isHiddenVariant(t))
       .sort((a, b) => a.order - b.order)
       .map((t) => ({
         slug: t.href.split("/").pop() as string,

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -26,16 +26,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { tools, roundedToolCount } from "@/lib/tools-config";
+import { tools, roundedToolCount, isHiddenVariant } from "@/lib/tools-config";
 import { playCue } from "@/lib/ui-sound";
 import s from "./command-palette.module.css";
 
 /* Locale-independent flat index — names/labels resolve via i18n at render.
-   Excludes SEO landing variants (`landingFor`) so the palette stays
-   consistent with the homepage grid, tool count, and related-tile pools. */
+   Excludes hidden SEO landing variants so the palette stays consistent with the
+   homepage grid and tool count; `inGrid` variants (PDF operations) are searchable
+   like any other card. */
 const TOOL_INDEX = tools.flatMap((c) =>
   c.items
-    .filter((t) => !t.landingFor)
+    .filter((t) => !isHiddenVariant(t))
     .map((t) => ({
       slug: t.href.split("/").pop() as string,
       href: t.href,

--- a/src/lib/tool-popularity.ts
+++ b/src/lib/tool-popularity.ts
@@ -33,6 +33,18 @@ export const TOOL_POPULARITY: string[] = [
   // — Tier 2: search-demand ranking (head-term volume, descending) —
   "qr-generator",        // "qr code generator" — one of the largest utility queries
   "password-generator",
+  // PDF operations — each a large head-term query ("merge pdf", "jpg to pdf",
+  // "compress pdf", …). Surfaced as their own cards (Tool.inGrid) and kept
+  // contiguous here so they read as a cluster in the grid.
+  "merge-pdf",
+  "jpg-to-pdf",
+  "compress-pdf",
+  "split-pdf",
+  "sign-pdf",
+  "rotate-pdf",
+  "watermark-pdf",
+  "extract-text-from-pdf",
+  "reorder-pdf-pages",
   "image-converter",     // heic→jpg / webp→png conversions
   "heic-to-jpg",
   "unit-converter",

--- a/src/lib/tools-config.ts
+++ b/src/lib/tools-config.ts
@@ -92,6 +92,11 @@ import {
   StampIcon,
   Gamepad2Icon,
   KeyboardIcon,
+  CombineIcon,
+  ShrinkIcon,
+  RotateCwIcon,
+  FileOutputIcon,
+  ListOrderedIcon,
 } from "lucide-react";
 
 export interface Tool {
@@ -115,6 +120,14 @@ export interface Tool {
    * (after `creationDate`) — scripts/generate-tool-routes.mjs regexes the
    * name → href → … available prefix, so keep required fields ahead of it. */
   landingFor?: string;
+  /** Set on a `landingFor` variant that should ALSO surface as its own grid
+   * card — a distinct user intent (e.g. the PDF operations merge/split/sign)
+   * that happens to share an implementation with its canonical tool. Such a
+   * variant is shown in the grid, counted, and searchable in the palette,
+   * while still belonging to its canonical's family for related tiles. Plain
+   * SEO long-tail variants (e.g. `compress-image-to-20kb`, the same tool at a
+   * preset) leave this unset and stay hidden. */
+  inGrid?: boolean;
 }
 
 export interface ToolCategory {
@@ -507,101 +520,110 @@ export const tools: ToolCategory[] = [
       {
         name: "Merge PDF",
         href: "/tools/merge-pdf",
-        icon: FileTextIcon,
+        icon: CombineIcon,
         available: true,
         order: 60,
         creationDate: "2026-07-16",
         description:
           "Combine multiple PDF files into one document, in order, right in your browser.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Split PDF",
         href: "/tools/split-pdf",
-        icon: FileTextIcon,
+        icon: ScissorsIcon,
         available: true,
         order: 61,
         creationDate: "2026-07-16",
         description:
           "Extract pages or page ranges from a PDF into separate files — no upload.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Compress PDF",
         href: "/tools/compress-pdf",
-        icon: FileTextIcon,
+        icon: ShrinkIcon,
         available: true,
         order: 62,
         creationDate: "2026-07-16",
         description:
           "Shrink PDF file size in your browser with three quality presets.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Rotate PDF",
         href: "/tools/rotate-pdf",
-        icon: FileTextIcon,
+        icon: RotateCwIcon,
         available: true,
         order: 63,
         creationDate: "2026-07-16",
         description:
           "Rotate PDF pages permanently — single pages or the whole document.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Watermark PDF",
         href: "/tools/watermark-pdf",
-        icon: FileTextIcon,
+        icon: StampIcon,
         available: true,
         order: 64,
         creationDate: "2026-07-16",
         description:
           "Stamp DRAFT, CONFIDENTIAL, or any text across every page of a PDF.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Sign PDF",
         href: "/tools/sign-pdf",
-        icon: FileTextIcon,
+        icon: SignatureIcon,
         available: true,
         order: 65,
         creationDate: "2026-07-16",
         description:
           "Draw or upload your signature and place it on any page — files never leave your device.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Extract Text from PDF",
         href: "/tools/extract-text-from-pdf",
-        icon: FileTextIcon,
+        icon: FileOutputIcon,
         available: true,
         order: 66,
         creationDate: "2026-07-16",
         description:
           "Pull selectable text out of a PDF and copy or download it as .txt.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Reorder PDF Pages",
         href: "/tools/reorder-pdf-pages",
-        icon: FileTextIcon,
+        icon: ListOrderedIcon,
         available: true,
         order: 67,
         creationDate: "2026-07-16",
         description:
           "Drag and drop to rearrange or delete PDF pages, then save.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "JPG to PDF",
         href: "/tools/jpg-to-pdf",
-        icon: FileTextIcon,
+        icon: FileImageIcon,
         available: true,
         order: 68,
         creationDate: "2026-07-16",
         description:
           "Turn JPG and PNG images into a single PDF with page size and margin controls.",
         landingFor: "pdf",
+        inGrid: true,
       },
       {
         name: "Zip Tools",
@@ -1901,12 +1923,21 @@ export const getAllTools = (): (Tool & { category: string })[] => {
   );
 };
 
-// Catalog tools — the public, user-facing set: every tool EXCEPT SEO landing
-// variants (entries carrying `landingFor`). This is what the homepage grid and
-// the marketing "N+ tools" count show. `getAllTools()` stays the full set so
-// sitemap / metadata / route + e2e generation keep landing variants visible.
+// A tool is hidden from the user-facing catalog surfaces (homepage grid,
+// marketing count, command palette) when it is a `landingFor` variant that is
+// NOT flagged `inGrid`. `inGrid` variants (e.g. the PDF operations) are distinct
+// intents that surface as their own cards while still belonging to their
+// canonical's family; plain SEO long-tail variants stay hidden. One predicate so
+// the grid, the count, and the palette can never drift apart.
+export const isHiddenVariant = (tool: Tool): boolean =>
+  !!tool.landingFor && !tool.inGrid;
+
+// Catalog tools — the public, user-facing set: every tool EXCEPT hidden SEO
+// landing variants. This is what the homepage grid and the marketing "N+ tools"
+// count show. `getAllTools()` stays the full set so sitemap / metadata / route +
+// e2e generation keep every landing variant visible.
 export const getCatalogTools = (): (Tool & { category: string })[] =>
-  getAllTools().filter((tool) => !tool.landingFor);
+  getAllTools().filter((tool) => !isHiddenVariant(tool));
 
 // Related-tile resolution shared by the ToolShell (spec §3, zone 5). Pure so it
 // can be unit-tested against a synthetic pool; defaults to the live catalog.


### PR DESCRIPTION
The PDF workbench showed a single "PDF Tools" card, but people search for "merge pdf", "split pdf", "compress pdf" by name and didn't find a card. Each operation already had its own route that opens the workbench on the right tab — these were hidden as SEO landing variants. This surfaces them as real cards.

## What changed
- **`inGrid` flag** on the `Tool` type — a `landingFor` variant that also surfaces as its own card (a distinct intent sharing an implementation), versus a plain long-tail variant that stays hidden. A single `isHiddenVariant` predicate now drives the grid, the tool count, and the command palette so they can't drift apart.
- The 9 PDF ops (merge, split, compress, rotate, watermark, sign, extract-text, reorder, jpg-to-pdf) are flagged `inGrid`, each gets a **distinct icon** (they all shared `FileText`), and they're ranked by search demand in `tool-popularity` so they cluster near the top of the grid instead of sinking to the bottom.
- The umbrella "PDF Tools" card stays. Each op card routes to the workbench with its operation preselected.
- Hidden image/mic/converter variants are unaffected — they have no `inGrid` flag.

## Notes
- Marketing count rises 140+ → 150+ (`getCatalogTools` now counts the surfaced ops). README stays at 141 — `validate` excludes all `landingFor` entries, so it's unchanged.
- Tests: +4 (`isHiddenVariant` behavior; catalog includes surfaced variants but excludes hidden ones). 801 total green, plus tsc, lint, validate, build.