### PR TITLE
Update llms.txt surfaces with clusters, data profiles, and honest limitations

### DIFF
--- a/src/__tests__/lib/llms-txt.test.ts
+++ b/src/__tests__/lib/llms-txt.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+
+import { GET as getLlmsTxt } from "@/app/llms.txt/route";
+import { GET as getLlmsFullTxt } from "@/app/llms-full.txt/route";
+import { tools } from "@/lib/tools-config";
+import { blogPosts } from "@/lib/blog-data";
+import { TOOL_CLUSTERS, CLUSTER_IDS, resolveClusterMembers } from "@/lib/tool-clusters";
+import { NETWORK_NOTES, dataProfileFor, touchesNetwork } from "@/lib/llms-data-profile";
+
+// Same "listed tools" definition as the two route handlers: available, and
+// excluding `landingFor` SEO variants — matches scripts/validate-tools.js's
+// count (152 as of this writing), not the larger set of route directories.
+const listedTools = tools
+  .flatMap((category) => category.items.filter((t) => t.available && !t.landingFor));
+
+async function textOf(response: Response): Promise<string> {
+  return response.text();
+}
+
+describe("/llms.txt", () => {
+  it("is force-static", async () => {
+    const mod = await import("@/app/llms.txt/route");
+    expect(mod.dynamic).toBe("force-static");
+  });
+
+  it("lists every available, non-landing tool with its URL", async () => {
+    const body = await textOf(getLlmsTxt());
+    for (const tool of listedTools) {
+      expect(body, `missing ${tool.href}`).toContain(`https://browserytools.com${tool.href}`);
+      expect(body, `missing name for ${tool.href}`).toContain(tool.name);
+    }
+  });
+
+  it("lists every blog post", async () => {
+    const body = await textOf(getLlmsTxt());
+    for (const post of blogPosts) {
+      expect(body, `missing ${post.slug}`).toContain(`/blog/${post.slug}`);
+    }
+  });
+
+  it("lists all five cluster hubs", async () => {
+    const body = await textOf(getLlmsTxt());
+    expect(body).toContain("## Collections");
+    for (const cluster of TOOL_CLUSTERS) {
+      expect(body, `missing hub ${cluster.id}`).toContain(
+        `https://browserytools.com${cluster.href}`,
+      );
+    }
+  });
+
+  it("does not open with an unqualified 'every tool runs 100% in your browser' claim", async () => {
+    const body = await textOf(getLlmsTxt());
+    // The old header asserted this for the whole catalogue; it wasn't true
+    // for model-download / remote tools. Guard against regressing to it.
+    expect(body).not.toMatch(/every tool runs 100%/i);
+    expect(body).not.toMatch(/works offline once loaded/i);
+  });
+
+  it("does not claim the site as a whole works offline (no service worker exists)", async () => {
+    // Scope to our own generated intro — a per-tool blog post description
+    // (e.g. the QR generator's) may legitimately say a specific tool works
+    // offline; this guards the site-wide framing text we control.
+    const body = await textOf(getLlmsTxt());
+    const intro = body.slice(0, body.indexOf("## Collections"));
+    expect(intro).not.toMatch(/\bworks offline\b/i);
+  });
+
+  it("flags every network-touching tool inline, next to its own listing", async () => {
+    const body = await textOf(getLlmsTxt());
+    for (const slug of Object.keys(NETWORK_NOTES)) {
+      const tool = listedTools.find((t) => t.href === `/tools/${slug}`);
+      if (!tool) continue; // not in the public listing (shouldn't happen, but don't fail on it)
+      const lineStart = body.indexOf(`https://browserytools.com${tool.href})`);
+      expect(lineStart, `${slug} not found in body`).toBeGreaterThan(-1);
+      const lineEnd = body.indexOf("\n", lineStart);
+      const line = body.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+      expect(line, `${slug} listing has no network qualifier`).toMatch(
+        /\[downloads an AI model|\[sends data to a third-party|\[fetches data from an external API/,
+      );
+    }
+  });
+});
+
+describe("/llms-full.txt", () => {
+  it("is force-static", async () => {
+    const mod = await import("@/app/llms-full.txt/route");
+    expect(mod.dynamic).toBe("force-static");
+  });
+
+  it("lists every available, non-landing tool with its URL and data profile", async () => {
+    const body = await textOf(getLlmsFullTxt());
+    for (const tool of listedTools) {
+      expect(body, `missing ${tool.href}`).toContain(`https://browserytools.com${tool.href})`);
+    }
+    expect(body).toContain("Data profile:");
+  });
+
+  it("lists every blog post with metadata", async () => {
+    const body = await textOf(getLlmsFullTxt());
+    for (const post of blogPosts) {
+      expect(body, `missing ${post.slug}`).toContain(`/blog/${post.slug}`);
+    }
+  });
+
+  it("expands every cluster hub with its full member list", async () => {
+    const body = await textOf(getLlmsFullTxt());
+    for (const id of CLUSTER_IDS) {
+      const members = resolveClusterMembers(id);
+      for (const member of members) {
+        expect(
+          body,
+          `cluster ${id} member ${member.slug} missing from llms-full.txt`,
+        ).toContain(`https://browserytools.com${member.href}`);
+      }
+    }
+  });
+
+  it("gives every network-touching tool its honest, hand-authored note", async () => {
+    const body = await textOf(getLlmsFullTxt());
+    for (const [slug, entry] of Object.entries(NETWORK_NOTES)) {
+      const tool = listedTools.find((t) => t.href === `/tools/${slug}`);
+      if (!tool) continue;
+      expect(body, `${slug} note missing`).toContain(entry.note);
+    }
+  });
+
+  it("never pairs a network-touching data profile with an unqualified 'nothing leaves your device' style claim", async () => {
+    const body = await textOf(getLlmsFullTxt());
+    const blocks = body.split(/(?=^### \[)/m);
+    for (const block of blocks) {
+      const hrefMatch = block.match(/^### \[.*?\]\(https:\/\/browserytools\.com(\/tools\/[a-z0-9-]+)\)/);
+      if (!hrefMatch) continue;
+      const slug = hrefMatch[1].replace(/^\/tools\//, "");
+      const profile = dataProfileFor(slug);
+      if (!touchesNetwork(profile)) continue;
+      // A network-touching tool's block must not carry the on-device fallback
+      // sentence, and must be tagged with a non-"on-device" data profile.
+      expect(block, `${slug} wrongly uses the on-device fallback note`).not.toContain(
+        "your file or text content is processed on-device and is never uploaded.",
+      );
+      expect(block, `${slug} missing its data profile tag`).toMatch(
+        /Data profile: (model-download|remote-processing|remote-data)/,
+      );
+    }
+  });
+
+  it("explicitly names Live Dictation's Web Speech API behavior and Currency Converter's live-rate fetch", async () => {
+    const body = await textOf(getLlmsFullTxt());
+    expect(body).toMatch(/Web Speech API/);
+    expect(body).toMatch(/browser vendor/i);
+    expect(body).toMatch(/exchange rates/i);
+  });
+});
+
+describe("llms-data-profile registry", () => {
+  it("every network-noted slug resolves to a real, available tool", () => {
+    const all = tools.flatMap((c) => c.items);
+    for (const slug of Object.keys(NETWORK_NOTES)) {
+      const tool = all.find((t) => t.href === `/tools/${slug}`);
+      expect(tool, `${slug} not found in tools-config`).toBeTruthy();
+      expect(tool?.available, `${slug} is not available`).toBe(true);
+    }
+  });
+
+  it("defaults an unknown slug to on-device", () => {
+    expect(dataProfileFor("definitely-not-a-real-tool")).toBe("on-device");
+    expect(touchesNetwork(dataProfileFor("definitely-not-a-real-tool"))).toBe(false);
+  });
+
+  it("classifies the verified network-touching tools correctly", () => {
+    expect(dataProfileFor("speech-to-text")).toBe("remote-processing");
+    expect(dataProfileFor("currency-converter")).toBe("remote-data");
+    expect(dataProfileFor("image-to-text")).toBe("model-download");
+    expect(dataProfileFor("audio-transcriber")).toBe("model-download");
+  });
+});

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,51 +1,145 @@
-import { tools, getCatalogTools } from "@/lib/tools-config";
+import { tools, type Tool } from "@/lib/tools-config";
 import { blogPosts } from "@/lib/blog-data";
+import { CLUSTERS_BASE_PATH, TOOL_CLUSTERS, resolveClusterMembers } from "@/lib/tool-clusters";
+import { NETWORK_NOTES, dataProfileFor, touchesNetwork } from "@/lib/llms-data-profile";
 
 // /llms-full.txt — expanded LLM/AI crawler index following the
 // https://llmstxt.org convention. Same structure as /llms.txt but with richer
-// per-item metadata (categories, dates, tags, read time) so models have full
-// context for accurate citation. Generated from the live config — no backend.
+// per-item metadata (category, date, data-profile, honest network notes)
+// so models have enough context to cite this site accurately instead of
+// repeating an unqualified "100% private, works offline" claim we can't back
+// for every tool. Generated from the live config — no backend.
 export const dynamic = "force-static";
 
 const BASE_URL = "https://browserytools.com";
 
+const DATA_PROFILE_LABEL: Record<string, string> = {
+  "on-device": "on-device",
+  "model-download": "model-download (AI model fetched from a CDN on first use, then on-device)",
+  "remote-processing": "remote-processing (sends data to a third-party service)",
+  "remote-data": "remote-data (fetches non-personal data from an external API)",
+};
+
+/**
+ * The public tool set in on-page category order: available, and excluding
+ * `landingFor` SEO variants — the same definition `scripts/validate-tools.js`
+ * uses for "tools in config" (152 as of this writing). The 176 route
+ * directories under /tools/ also count per-keyword landing-page variants of
+ * the same tool, which are not distinct tools.
+ */
+function listedTools(): (Tool & { category: string })[] {
+  const sortedCategories = [...tools].sort((a, b) => a.order - b.order);
+  return sortedCategories.flatMap((category) =>
+    category.items
+      .filter((t) => t.available && !t.landingFor)
+      .sort((a, b) => a.order - b.order)
+      .map((t) => ({ ...t, category: category.category })),
+  );
+}
+
 function buildLlmsFullTxt(): string {
   const lines: string[] = [];
-  const availableCount = getCatalogTools().filter((t) => t.available).length;
+  const catalog = listedTools();
+  const networkTools = catalog.filter((t) =>
+    touchesNetwork(dataProfileFor(t.href.replace(/^\/tools\//, ""))),
+  );
 
   lines.push("# BrowseryTools — Full Index");
   lines.push("");
   lines.push(
-    "> Free, fast, privacy-first browser tools. Every tool runs 100% in your browser — no uploads, no accounts, no tracking, no server processing. Files never leave your device. Works offline once loaded. Available in English and Arabic.",
+    `> Free, fast, privacy-first browser tools. ${catalog.length} tools spanning image, video, audio, text & language, developer, AI/LLM, calculator, security, and everyday utility categories. No sign-up, nothing to install — open a tool and use it immediately. Available in English, Arabic, Spanish, Portuguese (BR), French, German, Russian, Indonesian, and Simplified Chinese.`,
   );
   lines.push("");
   lines.push(
-    `BrowseryTools is a collection of ${availableCount} client-side web tools spanning image, video, audio, text & language, developer, AI/LLM, calculator, security, and everyday utility categories. There is no sign-up and nothing to install — open a tool and use it immediately. Because all processing happens in the browser via standard Web APIs (Canvas, WebAssembly, Web Crypto, File System Access, Wake Lock, etc.), the tools are private by design and suitable for sensitive files.`,
+    `**On the privacy claim, precisely:** for ${catalog.length - networkTools.length} of these ${catalog.length} tools, your file or text content is processed entirely on your device via standard Web APIs (Canvas, WebAssembly, Web Crypto, File System Access, Wake Lock, etc.) and is never uploaded. ${networkTools.length} tools are the exception, in two different ways:`,
+  );
+  lines.push("");
+  const modelDownloadTools = networkTools.filter(
+    (t) => dataProfileFor(t.href.replace(/^\/tools\//, "")) === "model-download",
+  );
+  const trulyRemoteTools = networkTools.filter((t) => {
+    const p = dataProfileFor(t.href.replace(/^\/tools\//, ""));
+    return p === "remote-processing" || p === "remote-data";
+  });
+  lines.push(
+    `- ${modelDownloadTools.length} tools (mostly the in-browser AI tools, built on Transformers.js/Xenova, Tesseract.js, or Segment Anything) download a model file from a third-party CDN the first time you use them, then run entirely on-device from then on. Your content still isn't uploaded — the network request is for the model, not your data.`,
+  );
+  lines.push(
+    `- ${trulyRemoteTools.length} tools genuinely send something over the network as part of what they do: ${trulyRemoteTools.map((t) => t.name).join(" and ")}. Each is called out individually below.`,
+  );
+  lines.push("");
+  lines.push(
+    "There is no service worker anywhere on this site, so no page — including the on-device ones — should be assumed to work fully offline.",
   );
   lines.push("");
   lines.push("---");
   lines.push("");
 
-  const sortedCategories = [...tools].sort((a, b) => a.order - b.order);
-  for (const category of sortedCategories) {
-    const available = category.items
-      .filter((t) => t.available && !t.landingFor)
-      .sort((a, b) => a.order - b.order);
-    if (available.length === 0) continue;
-
-    lines.push(`## ${category.category}`);
+  // Cluster hubs, with full member detail — the best entry point for a
+  // category-level question ("what would you recommend for redacting a PDF").
+  lines.push("## Collections");
+  lines.push("");
+  lines.push(
+    `Cross-category groupings under ${CLUSTERS_BASE_PATH}/ — each answers "what would someone search for" rather than "where does this live in the homepage grid". A tool can belong to more than one collection.`,
+  );
+  lines.push("");
+  for (const cluster of TOOL_CLUSTERS) {
+    const members = resolveClusterMembers(cluster.id);
+    lines.push(`### [${cluster.id.replace(/-/g, " ")}](${BASE_URL}${cluster.href})`);
     lines.push("");
-    for (const tool of available) {
+    lines.push(`- URL: ${BASE_URL}${cluster.href}`);
+    lines.push(`- Members: ${members.length}`);
+    if (cluster.related.length > 0) {
+      lines.push(`- Related collections: ${cluster.related.join(", ")}`);
+    }
+    lines.push("");
+    for (const member of members) {
+      const profile = dataProfileFor(member.slug);
+      const tag = profile === "on-device" ? "" : ` (${DATA_PROFILE_LABEL[profile]})`;
+      lines.push(`  - [${member.name}](${BASE_URL}${member.href})${tag}`);
+    }
+    lines.push("");
+  }
+  lines.push("---");
+  lines.push("");
+
+  // NOTE: comparison pages (/alternatives/*, src/lib/comparisons.ts) land on a
+  // separate branch. Once merged, add a "## Alternatives to" section here the
+  // same way as Collections above: import COMPARISONS, map each entry to its
+  // href/competitor/summary, done — no other change needed.
+
+  // Tools by category, with full per-tool detail.
+  const categoryOrder = [...new Set(catalog.map((t) => t.category))];
+  for (const categoryName of categoryOrder) {
+    const inCategory = catalog.filter((t) => t.category === categoryName);
+
+    lines.push(`## ${categoryName}`);
+    lines.push("");
+    for (const tool of inCategory) {
+      const slug = tool.href.replace(/^\/tools\//, "");
+      const profile = dataProfileFor(slug);
+      const networkNote = NETWORK_NOTES[slug];
+
       lines.push(`### [${tool.name}](${BASE_URL}${tool.href})`);
       lines.push("");
       lines.push(tool.description);
       lines.push("");
       lines.push(`- URL: ${BASE_URL}${tool.href}`);
-      lines.push(`- Category: ${category.category}`);
+      lines.push(`- Category: ${categoryName}`);
       lines.push(`- Added: ${tool.creationDate}`);
+      lines.push(`- Data profile: ${DATA_PROFILE_LABEL[profile]}`);
+      if (networkNote) {
+        lines.push(`- Note: ${networkNote.note}`);
+      } else {
+        lines.push(
+          "- Note: your file or text content is processed on-device and is never uploaded.",
+        );
+      }
       lines.push("");
     }
   }
+  lines.push("---");
+  lines.push("");
 
   const sortedPosts = [...blogPosts].sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,43 +1,93 @@
-import { tools } from "@/lib/tools-config";
+import { tools, type Tool } from "@/lib/tools-config";
 import { blogPosts } from "@/lib/blog-data";
+import { CLUSTERS_BASE_PATH, TOOL_CLUSTERS, resolveClusterMembers } from "@/lib/tool-clusters";
+import { touchesNetwork, dataProfileFor } from "@/lib/llms-data-profile";
 
 // /llms.txt — concise, machine-readable index of the site for LLM/AI crawlers,
 // following the https://llmstxt.org convention. Generated from the same config
-// that powers the UI so it never drifts out of sync.
+// that powers the UI (tools-config, tool-clusters, blog-data) so it never
+// drifts out of sync with what actually ships.
 //
 // Statically rendered at build time (no request-time work, no backend).
 export const dynamic = "force-static";
 
 const BASE_URL = "https://browserytools.com";
 
+/**
+ * The public tool set in on-page category order: available, and excluding
+ * `landingFor` SEO variants (the same definition `scripts/validate-tools.js`
+ * uses for "tools in config" — 152 as of this writing, not the 176 route
+ * directories, which also count per-variant landing pages).
+ */
+function listedTools(): (Tool & { category: string })[] {
+  const sortedCategories = [...tools].sort((a, b) => a.order - b.order);
+  return sortedCategories.flatMap((category) =>
+    category.items
+      .filter((t) => t.available && !t.landingFor)
+      .sort((a, b) => a.order - b.order)
+      .map((t) => ({ ...t, category: category.category })),
+  );
+}
+
 function buildLlmsTxt(): string {
   const lines: string[] = [];
+  const catalog = listedTools();
+  const networkToolCount = catalog.filter((t) =>
+    touchesNetwork(dataProfileFor(t.href.replace(/^\/tools\//, ""))),
+  ).length;
 
   lines.push("# BrowseryTools");
   lines.push("");
   lines.push(
-    "> Free, fast, privacy-first browser tools. Every tool runs 100% in your browser — no uploads, no accounts, no tracking. Image, video, audio, text, developer, AI, calculator, and utility tools that work offline once loaded.",
+    `> Free, fast, privacy-first browser tools. ${catalog.length} tools for image, video, audio, text, developer, AI, calculator, and everyday-utility tasks — no sign-up, nothing to install.`,
   );
   lines.push("");
   lines.push(
-    "All tools are client-side: files never leave your device. The site is also available in English and Arabic.",
+    `For the great majority of these tools your file or text content is processed on your device with standard Web APIs (Canvas, WebAssembly, Web Crypto, File System Access) and is never uploaded. A subset of tools (mostly ones built on in-browser AI models) download model weights from a third-party CDN the first time you use them, then run on-device after that — your content still isn't uploaded, but that first download is a network request. A small, named set of tools (currently ${networkToolCount}) genuinely send something over the network as part of what they do: Live Dictation uses the browser's own Speech Recognition API, which sends your audio to the browser vendor (Chrome/Edge) to produce a transcript, and Currency Converter fetches live exchange rates from an external API. See /llms-full.txt for the exact classification of every tool. There is no service worker, so no page here works fully offline.`,
+  );
+  lines.push("");
+  lines.push("The site is also available in Arabic, Spanish, Portuguese (BR), French, German, Russian, Indonesian, and Simplified Chinese.");
+  lines.push("");
+
+  // Cluster hubs — cross-category collections, the best entry point for a
+  // category-level question ("what PDF tools do you have").
+  lines.push("## Collections");
+  lines.push("");
+  for (const cluster of TOOL_CLUSTERS) {
+    const members = resolveClusterMembers(cluster.id);
+    lines.push(
+      `- [${cluster.id.replace(/-/g, " ")}](${BASE_URL}${cluster.href}): ${members.length} tools — ${members.map((m) => m.name).join(", ")}`,
+    );
+  }
+  lines.push("");
+  lines.push(
+    `Collections live under ${CLUSTERS_BASE_PATH}/ and group tools by what someone would search for rather than by homepage category.`,
   );
   lines.push("");
 
-  // Tools grouped by category, only available ones.
-  const sortedCategories = [...tools].sort((a, b) => a.order - b.order);
-  for (const category of sortedCategories) {
-    const available = category.items
-      .filter((t) => t.available)
-      .sort((a, b) => a.order - b.order);
-    if (available.length === 0) continue;
+  // NOTE: comparison pages (/alternatives/*, src/lib/comparisons.ts) land on a
+  // separate branch. Once merged, add an "## Alternatives to" section here the
+  // same way as Collections above — import COMPARISONS, one bullet per entry.
 
-    lines.push(`## ${category.category}`);
+  // Tools grouped by category, in on-page order.
+  const categoryOrder = [...new Set(catalog.map((t) => t.category))];
+  for (const categoryName of categoryOrder) {
+    const inCategory = catalog.filter((t) => t.category === categoryName);
+
+    lines.push(`## ${categoryName}`);
     lines.push("");
-    for (const tool of available) {
-      lines.push(
-        `- [${tool.name}](${BASE_URL}${tool.href}): ${tool.description}`,
-      );
+    for (const tool of inCategory) {
+      const slug = tool.href.replace(/^\/tools\//, "");
+      const profile = dataProfileFor(slug);
+      const suffix =
+        profile === "model-download"
+          ? " [downloads an AI model from a CDN on first use, then runs on-device]"
+          : profile === "remote-processing"
+            ? " [sends data to a third-party service — not fully on-device]"
+            : profile === "remote-data"
+              ? " [fetches data from an external API]"
+              : "";
+      lines.push(`- [${tool.name}](${BASE_URL}${tool.href}): ${tool.description}${suffix}`);
     }
     lines.push("");
   }

--- a/src/lib/llms-data-profile.ts
+++ b/src/lib/llms-data-profile.ts
@@ -1,0 +1,129 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// Network data-profile registry for the /llms.txt and /llms-full.txt surfaces.
+//
+// The homepage/marketing copy says tools are "client-side" as a category, but
+// that is not a uniform claim across all 152 tools: a subset downloads AI model
+// weights from a third-party CDN on first use, and two tools genuinely send
+// data over the network for their core function. This module is the single
+// source of truth those two route handlers pull from so the privacy claim in
+// generated output is qualified per tool instead of asserted once for everyone.
+//
+// Every entry here is backed by the tool's own implementation or its authored
+// UI copy (see the comments beside each group) — nothing is guessed:
+//   - "model-download" tools call `getPipeline()` (src/lib/hf-pipeline.ts,
+//     Transformers.js/Xenova), use the SAM segmenter (src/lib/sam-segment.ts),
+//     the imgly background-removal WASM+model bundle, or Tesseract.js — every
+//     one of these already ships an honest "downloads a model from a CDN"
+//     modelNote/privacyNote string in messages/en.json, quoted below.
+//   - "remote-processing" (speech-to-text): the component calls the browser's
+//     native `SpeechRecognition`/`webkitSpeechRecognition` API. In Chromium
+//     browsers that implementation sends the captured audio to the browser
+//     vendor's speech service — it is not on-device recognition.
+//   - "remote-data" (currency-converter): fetches exchange rates from
+//     api.frankfurter.app (falling back to exchangerate-api.com). No user
+//     content is sent — only the request for rates — but it is a live network
+//     dependency the tool cannot function without.
+// Every slug not listed here defaults to "on-device": the user's file/text
+// content is processed locally and never transmitted.
+//
+// Kept as its own module rather than added to tools-config.ts because that
+// file is parsed by scripts/validate-tools.js with a regex whose `items`
+// capture stops at the first `]`; an extra field on a tool entry there would
+// silently truncate the parse (see src/lib/tool-clusters.ts for the same
+// constraint applied to cluster membership).
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type ToolDataProfile =
+  | "on-device"
+  | "model-download"
+  | "remote-processing"
+  | "remote-data";
+
+export interface NetworkNote {
+  profile: ToolDataProfile;
+  /** One or two sentences, honest and specific, safe to quote verbatim. */
+  note: string;
+}
+
+// Slug = the segment after /tools/.
+export const NETWORK_NOTES: Record<string, NetworkNote> = {
+  // ── Transformers.js / Xenova models — src/lib/hf-pipeline.ts ─────────────
+  "audio-transcriber": {
+    profile: "model-download",
+    note: "Runs OpenAI Whisper entirely in your browser via WebGPU (with a WASM fallback). The model downloads once from a CDN on first use, then transcribes on-device — your audio is never uploaded.",
+  },
+  "subtitle-studio": {
+    profile: "model-download",
+    note: "Runs OpenAI Whisper entirely in your browser via WebGPU (with a WASM fallback). The model downloads once from a CDN on first use, then transcribes on-device — your video is never uploaded.",
+  },
+  "text-to-speech": {
+    profile: "model-download",
+    note: "AI voices run in your browser. The selected voice downloads a model (roughly 20-60MB) from a CDN the first time you use it, then plays and exports entirely on your device.",
+  },
+  "sentiment-analyzer": {
+    profile: "model-download",
+    note: "Runs a small AI model entirely in your browser. The model downloads once from a CDN on first use, then analyzes text on-device — nothing is uploaded.",
+  },
+  "text-summarizer": {
+    profile: "model-download",
+    note: "Runs a small AI summarization model entirely in your browser. The model downloads once from a CDN on first use, then summarizes text on-device — nothing is uploaded.",
+  },
+  translator: {
+    profile: "model-download",
+    note: "Runs an AI translation model entirely in your browser. The model (a few hundred MB) downloads once from a CDN on first use, then translates on-device — nothing is sent to Google, DeepL, or any server.",
+  },
+  "image-captioner": {
+    profile: "model-download",
+    note: "Runs a small image-to-text AI model entirely in your browser. The model downloads once from a CDN on first use, then generates captions on-device — your image is never uploaded.",
+  },
+  "pii-redactor": {
+    profile: "model-download",
+    note: "Runs a small AI named-entity-recognition model entirely in your browser, plus pattern matching for emails, phone numbers, credit cards, and IPs. The model downloads once from a CDN on first use, then runs on-device — your text is never uploaded.",
+  },
+  "depth-map": {
+    profile: "model-download",
+    note: "Runs a small AI depth-estimation model entirely in your browser. The model downloads once from a CDN on first use, then estimates depth on-device with WebGPU when available — nothing is uploaded.",
+  },
+  "zero-shot-classifier": {
+    profile: "model-download",
+    note: "Runs a small zero-shot AI model entirely in your browser. The model downloads once from a CDN on first use, then classifies text on-device against your labels — nothing is uploaded.",
+  },
+  "image-upscaler": {
+    profile: "model-download",
+    note: "Runs a super-resolution AI model entirely in your browser. The model downloads once from a CDN on first use, then upscales on-device — your image is never uploaded.",
+  },
+
+  // ── Other in-browser models ───────────────────────────────────────────────
+  "object-cutout": {
+    profile: "model-download",
+    note: "Runs the Segment Anything (SAM) model entirely in your browser. The model downloads once from a CDN on first use, then runs on-device — your image is never uploaded.",
+  },
+  "bg-removal": {
+    profile: "model-download",
+    note: "The AI background-removal model is downloaded once from a CDN and cached in your browser. Your images are processed entirely on your device and never leave it.",
+  },
+  "image-to-text": {
+    profile: "model-download",
+    note: "The OCR engine (Tesseract.js) runs entirely on your device. Its language data is downloaded once from the official tessdata CDN and cached — your image is never uploaded to any server.",
+  },
+
+  // ── Genuine network dependencies ──────────────────────────────────────────
+  "speech-to-text": {
+    profile: "remote-processing",
+    note: "Uses the browser's native Web Speech API rather than an on-device model. In Chrome and Edge, that API sends your captured audio to the browser vendor's speech-recognition service to produce the transcript — it is not private, on-device recognition.",
+  },
+  "currency-converter": {
+    profile: "remote-data",
+    note: "Fetches live exchange rates from an external API (Frankfurter, with an ExchangeRate-API fallback) on load. No file or text content is sent — only the request for current rates.",
+  },
+};
+
+/** Data profile for a tool slug; tools with no entry are plain on-device. */
+export function dataProfileFor(slug: string): ToolDataProfile {
+  return NETWORK_NOTES[slug]?.profile ?? "on-device";
+}
+
+/** True for any profile where something leaves the device for the tool to work. */
+export function touchesNetwork(profile: ToolDataProfile): boolean {
+  return profile !== "on-device";
+}


### PR DESCRIPTION
## Summary

`/llms.txt` and `/llms-full.txt` opened with a blanket claim that every tool runs 100% in the browser and works offline once loaded. That isn't true for the whole catalogue, so this corrects it and makes both files richer.

- Added `src/lib/llms-data-profile.ts`: classifies every tool into `on-device`, `model-download`, `remote-processing`, or `remote-data`, backed by each tool's own implementation (Transformers.js/Xenova, Tesseract.js, Segment Anything, the Web Speech API, the Frankfurter/ExchangeRate-API fetch) and its existing authored UI copy (modelNote/privacyNote strings in `messages/en.json`). 14 tools download an AI model from a CDN on first use then run on-device; Live Dictation sends audio to the browser vendor via the native Web Speech API in Chrome/Edge; Currency Converter fetches exchange rates from an external API. Everything else is plain on-device.
- `/llms.txt`: corrected header claim, per-tool network qualifiers inline, and a new `## Collections` section listing all five `/collections/*` cluster hubs with their members.
- `/llms-full.txt`: same corrected framing plus a `## Collections` section with full member detail, and a `Data profile:` + `Note:` line per tool giving the honest per-tool network story.
- Fixed the tool count to 152 (matches `bun run validate`) by excluding `landingFor` SEO variants consistently — the previous `/llms.txt` counted all 176 route-level variants.
- Both routes stay `force-static` and are generated purely from `tools-config.ts`, `blog-data.ts`, and `tool-clusters.ts` — no hardcoded lists, so they can't drift from the sitemap.
- Left a comment at the insertion point for the upcoming `/alternatives/*` comparison pages (`src/lib/comparisons.ts`), which live on a separate branch not in this tree — adding that section later is a small, obvious edit.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run test` — 1242 passing / 160 files (up from 1225/159 baseline; +17 new tests in `src/__tests__/lib/llms-txt.test.ts`)
- [x] `bun run lint` — 0 errors
- [x] `bun run validate` — 152 tools in config / 152 in README
- [x] `bun run dev` + curled both `/llms.txt` and `/llms-full.txt`, verified output by hand