### PR TITLE
Load only the active locale's messages on the client

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import {
   isLocale,
   ogAlternateLocales,
 } from "@/lib/locales";
+import { loadMessages } from "@/lib/messages";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -182,6 +183,12 @@ export default async function RootLayout({
     if (isLocale(localeCookie)) initialLocale = localeCookie;
   }
 
+  // Read the active locale's messages here, on the server, and hand them to the
+  // client provider as a prop. A client component cannot import them without
+  // bundling all of them, and the SSR'd HTML has to be translated — that prose
+  // is what crawlers index.
+  const initialMessages = await loadMessages(initialLocale);
+
   return (
     <html
       lang={initialLocale}
@@ -190,7 +197,11 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className={inter.className}>
-        <Providers initialLocale={initialLocale} localePinned={localePinned}>
+        <Providers
+          initialLocale={initialLocale}
+          initialMessages={initialMessages}
+          localePinned={localePinned}
+        >
           {children}
         </Providers>
       </body>

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/locales";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
+import { loadMessages } from "@/lib/messages";
 import { playCue } from "@/lib/ui-sound";
 
 interface LanguageSwitcherProps {
@@ -73,6 +74,15 @@ export function LanguageSwitcher({
         {LOCALES.map(({ code, label }) => (
           <DropdownMenuItem
             key={code}
+            // Each locale's messages are a separate lazy chunk now, so warm the
+            // one the pointer is on: by the time the click lands the switch is
+            // already instant. Cheap — the chunk is fetched at most once.
+            onPointerEnter={() => {
+              void loadMessages(code);
+            }}
+            onFocus={() => {
+              void loadMessages(code);
+            }}
             onClick={() => {
               setLocale(code);
               playCue("toggle");

--- a/src/lib/cluster-chrome.ts
+++ b/src/lib/cluster-chrome.ts
@@ -12,12 +12,13 @@
 // parity across every locale, which is the same guarantee the MISSING_MESSAGE
 // runtime error gives on the client, moved to build time.
 //
-// Message files are loaded with a dynamic import so only the requested locale's
-// JSON ends up being evaluated per request, rather than all nine.
+// Message files come from `src/lib/messages.ts`, which loads one locale's JSON
+// lazily rather than all of them.
 // ──────────────────────────────────────────────────────────────────────────────
 
 import { cookies } from "next/headers";
 import { defaultLocale, isLocale, type Locale } from "./locales";
+import { loadMessages } from "./messages";
 import type { ClusterId } from "./tool-clusters";
 
 export interface ClusterName {
@@ -41,21 +42,8 @@ export interface ClusterChrome {
   names: Record<ClusterId, ClusterName>;
 }
 
-const loaders: Record<Locale, () => Promise<{ default: unknown }>> = {
-  en: () => import("../../messages/en.json"),
-  ar: () => import("../../messages/ar.json"),
-  es: () => import("../../messages/es.json"),
-  "pt-BR": () => import("../../messages/pt-BR.json"),
-  fr: () => import("../../messages/fr.json"),
-  de: () => import("../../messages/de.json"),
-  ru: () => import("../../messages/ru.json"),
-  id: () => import("../../messages/id.json"),
-  "zh-CN": () => import("../../messages/zh-CN.json"),
-};
-
 export async function getClusterChrome(locale: Locale): Promise<ClusterChrome> {
-  const load = loaders[locale] ?? loaders[defaultLocale];
-  const messages = (await load()).default as { Clusters?: ClusterChrome };
+  const messages = (await loadMessages(locale)) as unknown as { Clusters?: ClusterChrome };
   if (!messages.Clusters) {
     throw new Error(
       `messages/${locale}.json is missing the "Clusters" namespace. ` +

--- a/src/lib/locales.ts
+++ b/src/lib/locales.ts
@@ -4,9 +4,9 @@
  * To add a new language:
  *   1. Add one entry to LOCALES below.
  *   2. Add the matching `messages/<code>.json` file (full translation of en.json).
- *   3. Register its import in `src/providers/language-provider.tsx` (messages map).
- * Everything else (switcher, html dir/lang, hreflang, openGraph, cookie handling)
- * derives from this registry automatically.
+ * That is the whole checklist — message files are loaded by path from the code
+ * below (`src/lib/messages.ts`), and everything else (switcher, html dir/lang,
+ * hreflang, openGraph, cookie handling) derives from this registry too.
  */
 
 export type Dir = "ltr" | "rtl";

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,27 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// The one way to get a locale's messages.
+//
+// `messages/*.json` is ~2.4 MB across the supported locales and grows with
+// every language added, but a visitor renders exactly one of them. So nothing
+// here is a static import: the template-literal `import()` makes the bundler
+// emit one lazy chunk per message file, and — because the path is derived
+// rather than listed — `src/lib/locales.ts` stays the only place a locale is
+// ever registered.
+//
+// Two callers:
+//   • `src/app/layout.tsx` (server) awaits the active locale's messages and
+//     passes them to `LanguageProvider` as a prop, so the SSR'd HTML is fully
+//     translated and hydration matches.
+//   • `LanguageProvider` (client) calls this only when the visitor switches to
+//     a locale other than the server-rendered one.
+// ──────────────────────────────────────────────────────────────────────────────
+
+import type { Messages } from "next-intl";
+import { defaultLocale, isLocale, type Locale } from "./locales";
+
+/** Load one locale's messages. Falls back to the default locale if unknown. */
+export async function loadMessages(locale: Locale): Promise<Messages> {
+  const target = isLocale(locale) ? locale : defaultLocale;
+  const mod = await import(`../../messages/${target}.json`);
+  return mod.default as Messages;
+}

--- a/src/providers/language-provider.tsx
+++ b/src/providers/language-provider.tsx
@@ -1,35 +1,26 @@
 "use client";
 
-import { NextIntlClientProvider } from "next-intl";
+import { NextIntlClientProvider, type Messages } from "next-intl";
 import { useLanguageStore } from "@/store/language-store";
 import { getDir, matchLocale, type Locale } from "@/lib/locales";
+import { loadMessages } from "@/lib/messages";
 import { useEffect, useRef, useState } from "react";
 import { Toaster } from "sonner";
-import enMessages from "../../messages/en.json";
-import arMessages from "../../messages/ar.json";
-import esMessages from "../../messages/es.json";
-import ptBRMessages from "../../messages/pt-BR.json";
-import frMessages from "../../messages/fr.json";
-import deMessages from "../../messages/de.json";
-import ruMessages from "../../messages/ru.json";
-import idMessages from "../../messages/id.json";
-import zhCNMessages from "../../messages/zh-CN.json";
-
-const messages: Record<Locale, typeof enMessages> = {
-  en: enMessages,
-  ar: arMessages,
-  es: esMessages,
-  "pt-BR": ptBRMessages,
-  fr: frMessages,
-  de: deMessages,
-  ru: ruMessages,
-  id: idMessages,
-  "zh-CN": zhCNMessages,
-};
 
 interface LanguageProviderProps {
   children: React.ReactNode;
   initialLocale: Locale;
+  /**
+   * `initialLocale`'s messages, resolved on the server. They arrive as a prop
+   * rather than being imported here on purpose: this is a client component, so
+   * an import would bundle *every* locale's JSON (~2.4 MB) into the chunk each
+   * visitor downloads to use exactly one of them. The server can read the
+   * message files without shipping them, and passing the resolved locale's
+   * messages down keeps the SSR'd HTML fully translated with no async gap and
+   * therefore no hydration mismatch. Other locales are fetched lazily, and
+   * only if the visitor actually switches language.
+   */
+  initialMessages: Messages;
   /**
    * True when `initialLocale` came from a `/{locale}/…` URL. A URL locale is
    * an explicit, shareable, indexable declaration — it must beat whatever
@@ -43,15 +34,24 @@ interface LanguageProviderProps {
 export function LanguageProvider({
   children,
   initialLocale,
+  initialMessages,
   localePinned = false,
 }: LanguageProviderProps) {
-  const { locale, dir, setLocale } = useLanguageStore();
+  const { locale, setLocale } = useLanguageStore();
   const initialized = useRef(false);
 
-  // Use server-resolved locale for the first render to avoid flash.
-  // After mount, follow Zustand (which rehydrates from localStorage) — unless
-  // the URL pinned the locale, in which case the URL stays authoritative.
-  const [currentLocale, setCurrentLocale] = useState<Locale>(initialLocale);
+  // Locale and messages move as one unit. Keeping them in a single state means
+  // the tree is never rendered with a locale whose messages have not arrived,
+  // so switching language shows the previous language until the new one is
+  // ready rather than flashing untranslated keys or English.
+  const [active, setActive] = useState<{ locale: Locale; messages: Messages }>({
+    locale: initialLocale,
+    messages: initialMessages,
+  });
+
+  // The locale that *should* be showing: the URL when it pinned one, otherwise
+  // whatever Zustand holds (rehydrated from localStorage, or set by the switcher).
+  const desiredLocale: Locale = localePinned ? initialLocale : locale;
 
   // A URL locale is also a preference change: persist it so the cookie, the
   // store and the switcher all agree with the address bar.
@@ -86,22 +86,35 @@ export function LanguageProvider({
     }
   }, [setLocale, localePinned]);
 
-  // Sync currentLocale with Zustand after it rehydrates from localStorage.
-  // A pinned (URL) locale is authoritative and never yields to the store.
+  // Bring `active` in line with `desiredLocale`, fetching that locale's chunk
+  // first. Nothing is committed until the messages resolve, and a switch that
+  // is superseded mid-flight is dropped.
   useEffect(() => {
-    setCurrentLocale(localePinned ? initialLocale : locale);
-  }, [locale, localePinned, initialLocale]);
+    if (desiredLocale === active.locale) return;
+    // Going back to the server-rendered locale needs no network at all.
+    if (desiredLocale === initialLocale) {
+      setActive({ locale: initialLocale, messages: initialMessages });
+      return;
+    }
+    let cancelled = false;
+    loadMessages(desiredLocale).then((messages) => {
+      if (!cancelled) setActive({ locale: desiredLocale, messages });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [desiredLocale, active.locale, initialLocale, initialMessages]);
 
-  // Keep html dir/lang in sync with React state
+  // Keep html dir/lang in sync with the locale actually being rendered.
   useEffect(() => {
-    document.documentElement.lang = currentLocale;
-    document.documentElement.dir = getDir(currentLocale);
-  }, [currentLocale]);
+    document.documentElement.lang = active.locale;
+    document.documentElement.dir = getDir(active.locale);
+  }, [active.locale]);
 
   return (
-    <NextIntlClientProvider locale={currentLocale} messages={messages[currentLocale]} timeZone="UTC">
+    <NextIntlClientProvider locale={active.locale} messages={active.messages} timeZone="UTC">
       {children}
-      <Toaster richColors position={dir === "rtl" ? "top-left" : "top-right"} />
+      <Toaster richColors position={getDir(active.locale) === "rtl" ? "top-left" : "top-right"} />
     </NextIntlClientProvider>
   );
 }

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -7,15 +7,23 @@ import { Analytics } from "@vercel/analytics/next";
 import { LanguageProvider } from "./language-provider";
 import { DynamicTitle } from "@/components/dynamic-title";
 import type { Locale } from "@/store/language-store";
+import type { Messages } from "next-intl";
 
 interface ProvidersProps {
   children: ReactNode;
   initialLocale: Locale;
+  /** `initialLocale`'s messages, read on the server — see LanguageProvider. */
+  initialMessages: Messages;
   /** True when the locale came from the URL and must win over stored state. */
   localePinned?: boolean;
 }
 
-export function Providers({ children, initialLocale, localePinned }: ProvidersProps) {
+export function Providers({
+  children,
+  initialLocale,
+  initialMessages,
+  localePinned,
+}: ProvidersProps) {
   return (
     <NextThemesProvider
       attribute="class"
@@ -23,7 +31,11 @@ export function Providers({ children, initialLocale, localePinned }: ProvidersPr
       enableSystem
       disableTransitionOnChange
     >
-      <LanguageProvider initialLocale={initialLocale} localePinned={localePinned}>
+      <LanguageProvider
+        initialLocale={initialLocale}
+        initialMessages={initialMessages}
+        localePinned={localePinned}
+      >
         <DynamicTitle />
         {/* Gate every framer-motion spring/transition (rail active pill, tool
             AnimatePresence, etc.) on the user's reduced-motion preference. */}


### PR DESCRIPTION
`src/providers/language-provider.tsx` is a client component that statically imported all nine `messages/*.json` files, so every visitor downloaded all of them in order to use one.

The active locale's messages are now read on the server in `src/app/layout.tsx` and passed to `LanguageProvider` as a prop, so SSR still emits fully translated HTML and hydration matches with no async gap. The other locales become separate lazy chunks, fetched only if the visitor switches language (and prefetched on hover/focus of the switcher item, so the switch stays instant). Locale and messages are held in one piece of state, so the tree is never rendered with a locale whose messages have not arrived.

`src/lib/messages.ts` resolves the message file by path rather than from a list, so `src/lib/locales.ts` stays the only place a locale is registered — the duplicate loader map in `src/lib/cluster-chrome.ts` is gone. English is not eagerly bundled: the server supplies whichever locale is active, including English, and there is no cross-locale fallback to hold it resident for.

## Measured

`bun run build` on `origin/main` and on this branch, then `next start` + `curl /tools/json-formatter`. "all JS" = every `/_next/static/**.js` referenced by that HTML, summed from disk; gzip is `gzip -6`. KB = 1024 B.

| | before raw | before gz | after raw | after gz |
|---|---|---|---|---|
| `chunks/app/layout-*.js` (where the messages lived) | 2037.6 | 599.5 | 15.9 | 6.5 |
| all JS the page requests (27 -> 26 files) | 3377.2 | 1026.9 | 1344.9 | 429.7 |
| HTML document | 70.2 | 14.5 | 278.9 | 75.4 |
| **total** | **3447.4** | **1041.4** | **1623.9** | **505.1** |

Net -52.9% raw, -51.5% gzipped. The HTML grows because the active locale's messages now travel in the RSC flight payload — that is the cost of keeping SSR translated, and it is one locale instead of nine.

Proof no other locale ships: `Пароль`, a string that occurs only in `messages/ru.json`, appears in exactly one file under `.next/static` — `chunks/71303.*.js`, 306.7 KB raw / 77.6 KB gz — and that file is not among the 26 scripts the English page requests. Before, the same string was inside `chunks/app/layout-*.js`, which every page loads. Other per-locale chunks, same shape: ar 257.0 / 70.6 KB, es 220.0 / 65.4 KB.

Other locales' HTML, same method: `/ar/tools/json-formatter` 17.0 -> 88.8 KB gz, `/de/tools/json-formatter` 12.8 -> 81.4 KB gz.

## Behaviour

- `curl` of `/tools/json-formatter`, `/ar/tools/json-formatter` and `/de/tools/json-formatter` returns fully translated prose in the raw HTML with `lang`/`dir` correct (`ar` is `dir="rtl"`).
- Headless Chromium, sampling the DOM every 30 ms across a switch: EN -> Arabic renders exactly two states, English then Arabic. No untranslated or English-after-switch frame.
- No hydration warnings in the dev console on `/tools/…`, `/ar/tools/…` or `/de/tools/…`.

Gates: `tsc --noEmit` clean, 1282/1282 tests, lint 0 errors, validate 152/152, `bun run build` succeeds.
