### PR TITLE
Fix locale-unaware casing and collation in tool search

### DIFF
--- a/src/__tests__/lib/tool-search-match.test.ts
+++ b/src/__tests__/lib/tool-search-match.test.ts
@@ -53,4 +53,33 @@ describe("matchesToolQuery()", () => {
     expect(matchesToolQuery(emptyKeywords, "transparent png")).toBe(false);
     expect(matchesToolQuery(emptyKeywords, "background")).toBe(true);
   });
+  // Regression: `"İmza".toLowerCase()` yields "i" + U+0307 COMBINING DOT ABOVE,
+  // so a Turkish user typing "imza" matched nothing and the tool was
+  // unreachable from search entirely.
+  describe("diacritic- and case-insensitive folding", () => {
+    it("finds a Turkish dotted-capital name from an ASCII query", () => {
+      const tr = { name: "İmza", category: "PDF Araçları", slug: "sign-pdf" };
+      expect(matchesToolQuery(tr, "imza")).toBe(true);
+    });
+
+    it("finds a Turkish dotless-i name from an ASCII query", () => {
+      const tr = { name: "Işık Ayarı", category: "Görsel", slug: "brightness" };
+      expect(matchesToolQuery(tr, "isik")).toBe(true);
+    });
+
+    it("finds a Vietnamese diacritic name from an unaccented query", () => {
+      const vi = { name: "Nén tệp", category: "Công cụ", slug: "zip" };
+      expect(matchesToolQuery(vi, "nen tep")).toBe(true);
+    });
+
+    it("finds a German umlaut/eszett name from an ASCII query", () => {
+      const de = { name: "Bildgröße", category: "Bilder", slug: "image-resizer" };
+      expect(matchesToolQuery(de, "bildgrosse")).toBe(true);
+    });
+
+    it("still rejects an unrelated query after folding", () => {
+      const tr = { name: "İmza", category: "PDF Araçları", slug: "sign-pdf" };
+      expect(matchesToolQuery(tr, "kahve")).toBe(false);
+    });
+  });
 });

--- a/src/components/landing/landing.tsx
+++ b/src/components/landing/landing.tsx
@@ -20,7 +20,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   tools,
   getAllTools,
@@ -497,6 +497,7 @@ function ToolRow({
 export default function Landing() {
   const t = useTranslations("Landing");
   const tc = useTranslations("ToolsConfig");
+  const locale = useLocale();
   const { category, setCategory } = useCategoryFilterStore();
   const [mounted, setMounted] = useState(false);
 
@@ -531,9 +532,11 @@ export default function Landing() {
       })).sort(
         (a, b) =>
           popularityRank(a.slug) - popularityRank(b.slug) ||
-          a.name.localeCompare(b.name),
+          // Collate in the active locale: an unqualified localeCompare() sorts
+          // non-English alphabets wrong (Turkish ç/ğ/ı/i/ö/ş/ü, for one).
+          a.name.localeCompare(b.name, locale),
       ),
-    [tc],
+    [tc, locale],
   );
 
   const popular = useMemo(

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -25,7 +25,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { tools, roundedToolCount, isHiddenVariant } from "@/lib/tools-config";
 import { playCue } from "@/lib/ui-sound";
 import { matchesToolQuery } from "@/lib/tool-search-match";
@@ -133,6 +133,7 @@ export function CommandPalette({
   animated?: boolean;
 }) {
   const router = useRouter();
+  const locale = useLocale();
   const t = useTranslations("Landing");
   const tRail = useTranslations("Rail");
   const tc = useTranslations("ToolsConfig");
@@ -147,8 +148,11 @@ export function CommandPalette({
         ...tool,
         name: tc(`tools.${tool.slug}.name` as never) as string,
         category: tc(`categoriesShort.${tool.categoryId}` as never) as string,
-      })).sort((a, b) => a.name.localeCompare(b.name)),
-    [tc],
+      // Sort in the active locale's collation — Turkish orders ç/ğ/ı/i/ö/ş/ü
+      // differently from the default, and an unqualified localeCompare() gets
+      // it wrong for every non-English alphabet on the site.
+      })).sort((a, b) => a.name.localeCompare(b.name, locale)),
+    [tc, locale],
   );
 
   const results = useMemo(() => {

--- a/src/lib/tool-search-match.ts
+++ b/src/lib/tool-search-match.ts
@@ -17,20 +17,63 @@ export interface SearchableTool {
 }
 
 /**
- * True if the (already-lowercased-by-caller-agnostic) `query` matches this
- * tool. Pass the raw query — matching is case-insensitive internally.
+ * Letters that carry no combining mark to strip, so NFD leaves them alone.
+ * Each is folded to the base letter a user is likely to type on a keyboard
+ * that lacks it.
+ *
+ * `ı` (Turkish dotless i) is the important one: `"İmza".toLowerCase()` yields
+ * `i` + U+0307 COMBINING DOT ABOVE, so a Turkish user typing `imza` matched
+ * nothing at all and the tool was unreachable from search. Stripping combining
+ * marks fixes that direction; this table fixes the reverse, where the tool
+ * name contains `ı` and the query contains `i`.
+ */
+const NON_DECOMPOSING_FOLDS: Record<string, string> = {
+  ı: "i",
+  ł: "l",
+  đ: "d",
+  ð: "d",
+  ø: "o",
+  æ: "ae",
+  œ: "oe",
+  ß: "ss",
+  "ẞ": "ss",
+};
+
+/**
+ * Fold a string for search comparison: decompose, drop combining marks, lower
+ * case, then fold the letters that decomposition cannot reach.
+ *
+ * Deliberately locale-independent. A locale-aware `toLocaleLowerCase(locale)`
+ * would fix Turkish only for Turkish users, but the catalogue is searched in
+ * 17 languages and a visitor may type a query in one script against a tool
+ * name in another. Diacritic-insensitive folding means `imza` finds `İmza`,
+ * `isik` finds `ışık`, `tep` finds `tệp`, and `grosse` finds `größe`.
+ */
+export function foldForSearch(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase()
+    .replace(/[ıłđðøæœßẞ]/g, (c) => NON_DECOMPOSING_FOLDS[c] ?? c);
+}
+
+/**
+ * True if `query` matches this tool. Pass the raw query — matching is
+ * case- and diacritic-insensitive internally.
  */
 export function matchesToolQuery(tool: SearchableTool, query: string): boolean {
-  const q = query.trim().toLowerCase();
+  const q = foldForSearch(query.trim());
   if (!q) return true;
 
   if (
-    tool.name.toLowerCase().includes(q) ||
-    tool.category.toLowerCase().includes(q) ||
-    tool.slug.toLowerCase().includes(q)
+    foldForSearch(tool.name).includes(q) ||
+    foldForSearch(tool.category).includes(q) ||
+    foldForSearch(tool.slug).includes(q)
   ) {
     return true;
   }
 
-  return (tool.keywords ?? []).some((keyword) => keyword.toLowerCase().includes(q));
+  return (tool.keywords ?? []).some((keyword) =>
+    foldForSearch(keyword).includes(q)
+  );
 }


### PR DESCRIPTION
Turkish surfaced a real bug while its translation was being reviewed.

`"İmza".toLowerCase()` returns `i` + U+0307 COMBINING DOT ABOVE, so a Turkish user typing `imza` got zero results — the tool was unreachable from both search and the ⌘K palette. Verified in node before fixing.

**Search** (`src/lib/tool-search-match.ts`) now folds diacritics via NFD + combining-mark strip, plus a small table for letters that don't decompose (`ı ł đ ð ø æ œ ß`). Deliberately locale-independent rather than `toLocaleLowerCase(locale)`: the catalogue is searched in many languages and a visitor may type a query in a different script from the tool name.

`imza` → `İmza` · `isik` → `ışık` · `nen tep` → `Nén tệp` · `bildgrosse` → `Bildgröße`

**Sorting** in the command palette and landing grid passed no locale to `localeCompare()`, mis-ordering every non-English alphabet. Both now pass the active locale.

5 regression tests added. Gates: tsc clean, 1317 tests passing, lint 0 errors, validate 152/152.