### PR TITLE
feat: add baseline security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,31 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   async headers() {
     return [
+            {
+        // Baseline security headers for every route.
+        //
+        // Content-Security-Policy is deliberately left out: the AI tools fetch
+        // models from huggingface.co and staticimgly.com at runtime and run
+        // them through WebAssembly, so a policy here would need
+        // 'wasm-unsafe-eval' and an allowlist for those hosts, and Next.js
+        // needs nonce handling for its inline bootstrap script. That is a
+        // design decision for the maintainer, not something to slip into a
+        // header patch.
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            // The camera, microphone and screen-capture tools run on this
+            // origin; no embedded third party should inherit those grants.
+            key: "Permissions-Policy",
+            value:
+              "camera=(self), microphone=(self), display-capture=(self), geolocation=()",
+          },
+        ],
+      },
+
       {
         source: "/tools/bg-removal",
         headers: [{ key: "Cross-Origin-Opener-Policy", value: "same-origin" }],


### PR DESCRIPTION

There is no `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy` or
`Permissions-Policy` on any route.

## Why it matters here

Two of these are worth more than usual for this project:

**Framing.** Every tool page can be loaded inside an iframe on any origin. For a
site whose promise is "your files never leave your browser", an attacker can
frame a tool, overlay it, and drive a user's clicks somewhere else while the
address bar they trust is out of sight. I could not find anywhere the app
relies on being embedded, so `DENY` should be safe.

**Camera and microphone.** `getUserMedia` is used by BarcodeScanner, QRScanner,
CameraCapture, ScreenRecorder and the two media-tester panels. Without
`Permissions-Policy` those grants are not scoped, so an embedded third party can
inherit them. Restricting them to `self` keeps the tools working while closing
that off.

## What this changes

Adds one header block covering `/:path*`. The three existing rules (the COOP
header on `/tools/bg-removal` and the two `Cache-Control` rules) are untouched —
this is 24 added lines and nothing removed.

## What this deliberately leaves out

No `Content-Security-Policy`. The AI tools pull models from `huggingface.co` and
`staticimgly.com` at runtime and execute them through WebAssembly, so a policy
would need `'wasm-unsafe-eval'` plus an allowlist for those hosts, and Next.js
needs nonce handling for its inline bootstrap. Getting that wrong silently
breaks tools, so it seemed better left to you as a separate decision. Happy to
open an issue with a draft policy if that is useful.

---

_Disclosure: I used AI assistance to survey the codebase and check the live
headers. The header choices and the decision to leave CSP out are mine, and I
verified the config still emits all four rule blocks after the change._
